### PR TITLE
added provider block for dynamodb table

### DIFF
--- a/terraform/automation.tf
+++ b/terraform/automation.tf
@@ -443,6 +443,8 @@ resource "aws_cloudwatch_log_group" "vpnactions_lambda_log_group" {
 
 # DynamoDB Table
 resource "aws_dynamodb_table" "dynamodb_table" {
+  provider = aws.awsoregon
+  
   name           = "network-manager-vpn-actions"
   read_capacity  = 1
   write_capacity = 1


### PR DESCRIPTION
*Issue #, if available:*
Adding provider block in the dynamoDB configuration. Tried deploying this solution where my CLI defaulted to another region other than us-west-2 where i had a SCP and the deployment failed.

*Description of changes:*
Change provider block to awsoregon.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
